### PR TITLE
Avoid newlines when writing string secrets

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -56,7 +56,7 @@ if [[ -f "$VAULT_SECRETS_FILE" ]]; then
     if [ $type = 'object' ] || [ $type = 'array' ]; then
       echo "$value" | vault write "${path}" -
     else
-      echo "$value" | vault write "${path}" value=-
+      vault write "${path}" "value=${value}"
     fi
   done
 else


### PR DESCRIPTION
First of all, thanks for writing this fork! I was literally about to do a number of these things to get the dev container working again, but then I found yours :)

This PR fixes an issue I noticed with string secrets. They are being stored with a newline following the string, like when we store `bar`, it comes back as `bar\n`